### PR TITLE
fix: add import os in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,6 @@
+import os
 from setuptools import setup, find_packages
+
 
 required_packages = [
   'graphene>=2.0',


### PR DESCRIPTION
solved error on pip install for missing import